### PR TITLE
Fixed UnityPackage Pathing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,15 @@ jobs:
           type: "zip"
           directory: "${{env.packageName}}/"
           filename: "../${{env.zipFile}}" # make the zip file one directory up, since we start one directory in above
+
+      - name: Create Packages Directory and Move Files
+        run: |
+          if [ ! -d "Packages" ]; then
+            mkdir Packages
+            mv ${{env.packageName}} Packages/
+          fi
           
-      - run: find "${{env.packageName}}/" -name \*.meta >> metaList
+      - run: find "Packages/${{env.packageName}}/" -name \*.meta >> metaList
           
       - name: Create UnityPackage
         uses: pCYSl5EDgo/create-unitypackage@cfcd3cf0391a5ef1306342794866a9897c32af0b
@@ -56,4 +63,4 @@ jobs:
           files: |
             ${{ env.zipFile }}
             ${{ env.unityPackage }}
-            ${{ env.packageName }}/package.json
+            Packages/${{ env.packageName }}/package.json


### PR DESCRIPTION
The .unitypackage generated automatically by the github workflow did not import into `Packages/com.dreadscripts.example` and instead imports alongside `Assets/` and `Packages/` in the root project folder.

The proposed changes move the package into a `Packages/` directory prior to building the .unitypackage for release.

The .zip generated had no issues.